### PR TITLE
 add half price to sizes

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -62,7 +62,7 @@ private
 
   def item_params
     params.require(:item).permit(:name, :description, :kind, :qualifier, :size_selection, :order_id,
-      sizes_attributes: [:name, :price, :id, :_destroy],
+      sizes_attributes: [:name, :price, :half_price, :id, :_destroy],
       topping_ids: [])
   end
 end

--- a/app/views/items/_size_fields.html.haml
+++ b/app/views/items/_size_fields.html.haml
@@ -1,4 +1,5 @@
 .nested-fields
   = f.input :name
   = f.input :price
+  = f.input :half_price
   = link_to_remove_association 'remove size', f

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -6,6 +6,7 @@
   - @item.sizes.each do |s|
     = s.name
     = s.price
+    = s.half_price
 - @item.toppings.each do |t|
   = t.name
 - if policy(@item).update?

--- a/db/migrate/20160225211010_add_half_price_to_sizes.rb
+++ b/db/migrate/20160225211010_add_half_price_to_sizes.rb
@@ -1,0 +1,5 @@
+class AddHalfPriceToSizes < ActiveRecord::Migration
+  def change
+    add_column :sizes, :half_price, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160219100046) do
+ActiveRecord::Schema.define(version: 20160225211010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20160219100046) do
     t.integer  "toppings_id"
     t.string   "qualifier"
     t.integer  "order_id"
+    t.integer  "side_one_id"
   end
 
   add_index "items", ["toppings_id"], name: "index_items_on_toppings_id", using: :btree
@@ -74,6 +75,7 @@ ActiveRecord::Schema.define(version: 20160219100046) do
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
     t.integer  "item_id"
+    t.float    "half_price"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/features/admin/can_crud_item_test.rb
+++ b/test/features/admin/can_crud_item_test.rb
@@ -47,6 +47,21 @@ feature 'admin can CRUD items' do
     page.must_have_content 'pagliaccio dressing'
     page.must_have_content 'Item was successfully created.'
   end
+  scenario 'admin wants to add a half size for a pizza', js: true do
+    test_item = items(:the_original)
+    visit edit_item_path test_item
+
+    click_on 'Add Size'
+    find('.item_sizes_name input').set('Small')
+    find('.item_sizes_price input').set('11.99')
+    find('.item_sizes_half_price input').set('5.99')
+    click_on 'Save'
+
+    page.must_have_content 'Small'
+    page.must_have_content '11.99'
+    page.must_have_content '5.99'
+    page.must_have_content 'Item was successfully updated'
+  end
   scenario 'admin wants to edit a item', js: true do
     test_item = items(:caesar)
     visit item_path test_item


### PR DESCRIPTION
Adds half_price fields to sizes table so admin can set a price for the price of a one half pizza – for when customers need to order half and half pies.